### PR TITLE
Use ArchWiki search API for recommendations and to check if page exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "termination",
  "thiserror",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,6 @@ dependencies = [
  "colored",
  "directories",
  "ego-tree",
- "fuzzy-matcher",
  "html2md",
  "human-panic",
  "itertools",
@@ -490,15 +489,6 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
-]
-
-[[package]]
-name = "fuzzy-matcher"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
-dependencies = [
- "thread_local",
 ]
 
 [[package]]
@@ -1746,16 +1736,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.29",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
-dependencies = [
- "cfg-if",
- "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde_yaml = "0.9.21"
 termination = "0.1.2"
 thiserror = "1.0.40"
 tokio = { version = "1.28.0", features = ["full"] }
+url = "2.4.1"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ clap = { version = "4.2.5", features = ["derive"] }
 colored = "2.0.0"
 directories = "5.0.1"
 ego-tree = "0.6.2"
-fuzzy-matcher = "0.3.7"
 html2md = "0.2.14"
 human-panic = "1.1.5"
 itertools = "0.10.5"

--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ A CLI tool to read pages from the ArchWiki
 
 ## Installation
 Currently, you can only install this tool from [ crates.io ](https://crates.io/crates/archwiki-rs) 
-or build it from source. 
-
-After you are finished with the installation you should run [update-all](#updating-everything).
+or build it from source
 
 ### crates.io
 
@@ -65,9 +63,7 @@ been modified in the last 14 days.
 #### 404 page not found (-̥̥̥n-̥̥̥ )
 
 If the page you are searching for doesn't exist, a list of the pages that are most similar
-(in name) to the page you asked for will be output instead of the page content. The
-categories are stored locally and can be fetched with the [update-all](#updating-everything) 
-command.
+(in name) to the page you asked for will be output instead of the page content 
 
 ```sh
 archwiki-rs read-page Neovi
@@ -87,7 +83,7 @@ under the name `example.sh`.
 
 ### Downloading page info
 
-The page names used for suggestions are stored locally to prevent having to scrape the entire table of contents of
+Page names are stored locally to prevent having to scrape the entire table of contents of
 the ArchWiki with every command
 
 #### Updating everything

--- a/src/categories.rs
+++ b/src/categories.rs
@@ -51,7 +51,7 @@ pub fn list_pages(categories: &HashMap<String, Vec<String>>, flatten: bool) -> S
 ///
 /// Caution this function will most likely take several minutes to finish (-, – )…zzzZZ
 pub async fn fetch_all_page_names() -> Result<HashMap<String, Vec<String>>, WikiError> {
-    let document = fetch_page("Table_of_contents").await?;
+    let document = fetch_page("Table_of_contents", None).await?;
     let selector =
         Selector::parse(".mw-parser-output").expect(".mw-parser-output to be a valid css selector");
 

--- a/src/categories.rs
+++ b/src/categories.rs
@@ -4,7 +4,8 @@ use std::collections::HashMap;
 
 use crate::{
     error::WikiError,
-    utils::{extract_tag_attr, fetch_page, HtmlTag},
+    utils::{extract_tag_attr, HtmlTag},
+    wiki_api::fetch_page,
 };
 
 /// Returns a print ready list of the provided page names in

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,31 @@
-use std::{io, time::SystemTimeError};
+use std::{fmt, io, time::SystemTimeError};
 
 use thiserror::Error;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum InvalidApiResponseError {
+    OpenSearchMissingNthElement(usize),
+    OpenSearchNthElementShouldBeArray(usize),
+    OpenSearchArraysLengthMismatch,
+}
+
+impl fmt::Display for InvalidApiResponseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let str = match self {
+            Self::OpenSearchMissingNthElement(n) => {
+                format!("missing element #{n} in open search response")
+            }
+            Self::OpenSearchNthElementShouldBeArray(n) => {
+                format!("expected element #{n} in open search response to be an array")
+            }
+            Self::OpenSearchArraysLengthMismatch => {
+                "arrays in open search response should have the same length but do not".to_owned()
+            }
+        };
+
+        write!(f, "{str}")
+    }
+}
 
 #[derive(Error, Debug)]
 pub enum WikiError {
@@ -18,6 +43,8 @@ pub enum WikiError {
     Path(String),
     #[error("A HTML error occurred.\nERROR: {}", .0)]
     Html(String),
+    #[error("An invalid api response was received.\nERROR: {}", .0)]
+    InvalidApiResponse(InvalidApiResponseError),
     #[error("{}", .0)]
     NoPageFound(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use std::{fmt, io, time::SystemTimeError};
 use thiserror::Error;
 
 #[derive(Debug, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)]
 pub enum InvalidApiResponseError {
     OpenSearchMissingNthElement(usize),
     OpenSearchNthElementShouldBeArray(usize),

--- a/src/formats/html.rs
+++ b/src/formats/html.rs
@@ -2,7 +2,7 @@ use scraper::Html;
 
 use crate::{
     error::WikiError,
-    utils::{get_page_content, get_top_pages},
+    utils::{get_page_content, search_for_similar_pages},
 };
 
 /// Converts the body of the ArchWiki page to a HTML string.
@@ -12,15 +12,11 @@ use crate::{
 ///
 /// Errors:
 /// - If it fails to fetch the page
-pub async fn convert_page_to_html(
-    document: &Html,
-    page: &str,
-    pages: &[&str],
-) -> Result<String, WikiError> {
+pub async fn convert_page_to_html(document: &Html, page: &str) -> Result<String, WikiError> {
     let content = match get_page_content(&document) {
         Some(content) => content,
         None => {
-            let recommendations = get_top_pages(page, 5, pages);
+            let recommendations = search_for_similar_pages(page, None, None).await?;
             return Err(WikiError::NoPageFound(recommendations.join("\n")));
         }
     };
@@ -56,7 +52,7 @@ mod tests {
         );
 
         let document = Html::parse_document(&input);
-        let output = convert_page_to_html(&document, page, &[]).await.unwrap();
+        let output = convert_page_to_html(&document, page).await.unwrap();
 
         assert_eq!(output, expected_output);
     }

--- a/src/formats/html.rs
+++ b/src/formats/html.rs
@@ -1,32 +1,16 @@
 use scraper::Html;
 
-use crate::{
-    error::WikiError,
-    utils::{get_page_content, search_for_similar_pages},
-};
+use crate::utils::get_page_content;
 
-/// Converts the body of the ArchWiki page to a HTML string.
-///
-/// If the ArchWiki page doesn't have content the top 5 pages that are most
-/// like the page that was given as an argument are returned as a `NoPageFound` error.
-///
-/// Errors:
-/// - If it fails to fetch the page
-pub async fn convert_page_to_html(document: &Html, page: &str) -> Result<String, WikiError> {
-    let content = match get_page_content(&document) {
-        Some(content) => content,
-        None => {
-            let recommendations = search_for_similar_pages(page, None, None).await?;
-            return Err(WikiError::NoPageFound(recommendations.join("\n")));
-        }
-    };
+/// Converts the body of the ArchWiki page to a HTML string
+pub fn convert_page_to_html(document: &Html, page: &str) -> String {
+    let content = get_page_content(document).expect("page should have content");
 
-    let res = format!(
+    format!(
         "<h1>{heading}</h1>\n{body}",
         heading = page,
         body = content.html()
-    );
-    Ok(res)
+    )
 }
 
 #[cfg(test)]
@@ -52,7 +36,7 @@ mod tests {
         );
 
         let document = Html::parse_document(&input);
-        let output = convert_page_to_html(&document, page).await.unwrap();
+        let output = convert_page_to_html(&document, page);
 
         assert_eq!(output, expected_output);
     }

--- a/src/formats/plain_text.rs
+++ b/src/formats/plain_text.rs
@@ -90,7 +90,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[tokio::test]
-    async fn test_convert_page_to_markdown() {
+    async fn test_convert_page_to_plain_text() {
         {
             let input = format!(
                 r#"<div class="{PAGE_CONTENT_CLASS}">

--- a/src/formats/plain_text.rs
+++ b/src/formats/plain_text.rs
@@ -115,7 +115,6 @@ mod tests {
         }
 
         {
-            let page = "page with links";
             let input = format!(
                 r#"<div class="{PAGE_CONTENT_CLASS}">
     <h3>Hello, world!</h3>

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,12 +86,10 @@ async fn main() -> Result<(), WikiError> {
 
                 match format {
                     PageFormat::PlainText => {
-                        convert_page_to_plain_text(&document, &page, &pages, show_urls).await?
+                        convert_page_to_plain_text(&document, &page, show_urls).await?
                     }
-                    PageFormat::Markdown => {
-                        convert_page_to_markdown(&document, &page, &pages).await?
-                    }
-                    PageFormat::Html => convert_page_to_html(&document, &page, &pages).await?,
+                    PageFormat::Markdown => convert_page_to_markdown(&document, &page).await?,
+                    PageFormat::Html => convert_page_to_html(&document, &page).await?,
                 }
             };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,8 @@ use itertools::Itertools;
 use crate::{
     formats::{html::convert_page_to_html, markdown::convert_page_to_markdown, PageFormat},
     languages::{fetch_all_langs, format_lang_table},
-    utils::{create_cache_page_path, fetch_page, page_cache_exists},
+    utils::{create_cache_page_path, page_cache_exists},
+    wiki_api::fetch_page,
 };
 
 mod categories;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,13 +27,6 @@ impl HtmlTag {
     }
 }
 
-/// Selects the body of an ArchWiki page
-pub fn get_page_content(document: &Html) -> Option<ElementRef<'_>> {
-    let class = format!(".{PAGE_CONTENT_CLASS}");
-    let selector = Selector::parse(&class).expect(&format!("{class} should be valid selector"));
-    document.select(&selector).next()
-}
-
 /// Construct a path to cache a page. Different page formats are cached separately.
 /// All none word characters are escaped with an '_'
 pub fn create_cache_page_path(page: &str, format: &PageFormat, cache_dir: &Path) -> PathBuf {
@@ -67,6 +60,14 @@ pub fn page_cache_exists(
         .as_secs();
 
     Ok(secs_since_modified < fourteen_days)
+}
+
+/// Selects the body of an ArchWiki page
+pub fn get_page_content(document: &Html) -> Option<ElementRef<'_>> {
+    let class = format!(".{PAGE_CONTENT_CLASS}");
+    let selector =
+        Selector::parse(&class).unwrap_or_else(|_| panic!("{class} should be valid selector"));
+    document.select(&selector).next()
 }
 
 pub fn extract_tag_attr(element: &Element, tag: &HtmlTag, attr: &str) -> Option<String> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,11 @@ use itertools::Itertools;
 use regex::Regex;
 use scraper::{node::Element, ElementRef, Html, Selector};
 
-use crate::{error::WikiError, formats::PageFormat};
+use crate::{
+    error::{InvalidApiResponseError, WikiError},
+    formats::PageFormat,
+    wiki_api::OpenSearchItem,
+};
 
 pub const PAGE_CONTENT_CLASS: &str = "mw-parser-output";
 
@@ -31,15 +35,45 @@ pub fn get_page_content(document: &Html) -> Option<ElementRef<'_>> {
     document.select(&selector).next()
 }
 
-/// Gets an ArchWiki pages entire content. Also updates all relative URLs to absolute URLs.
-/// `/title/Neovim` -> `https://wiki.archlinux.org/title/Neovim`
-pub async fn fetch_page(page: &str) -> Result<Html, reqwest::Error> {
-    let url = format!("https://wiki.archlinux.org/title/{page}");
+/// Convert an open search response into a list of name and URL pairs
+///
+/// Errors:
+/// - If the search results don't have an array as the 1. and 3. elements in the list
+/// - If the arrays in the search results have different lengths
+pub fn open_search_to_page_url_tupel(
+    search_result: Vec<OpenSearchItem>,
+) -> Result<Vec<(String, String)>, WikiError> {
+    let page_names = search_result.get(1).ok_or(WikiError::InvalidApiResponse(
+        InvalidApiResponseError::OpenSearchMissingNthElement(1),
+    ))?;
 
-    let body = reqwest::get(&url).await?.text().await?;
-    let body_with_abs_urls = update_relative_urls(&body);
+    let page_urls = search_result.get(3).ok_or(WikiError::InvalidApiResponse(
+        InvalidApiResponseError::OpenSearchMissingNthElement(3),
+    ))?;
 
-    Ok(Html::parse_document(&body_with_abs_urls))
+    if let OpenSearchItem::Array(names) = page_names {
+        if let OpenSearchItem::Array(urls) = page_urls {
+            if names.len() != urls.len() {
+                return Err(WikiError::InvalidApiResponse(
+                    InvalidApiResponseError::OpenSearchArraysLengthMismatch,
+                ));
+            }
+
+            Ok(names
+                .into_iter()
+                .zip(urls)
+                .map(|(a, b)| (a.to_owned(), b.to_owned()))
+                .collect_vec())
+        } else {
+            Err(WikiError::InvalidApiResponse(
+                InvalidApiResponseError::OpenSearchNthElementShouldBeArray(3),
+            ))
+        }
+    } else {
+        Err(WikiError::InvalidApiResponse(
+            InvalidApiResponseError::OpenSearchNthElementShouldBeArray(1),
+        ))
+    }
 }
 
 /// Construct a path to cache a page. Different page formats are cached separately.
@@ -52,11 +86,6 @@ pub fn create_cache_page_path(page: &str, format: &PageFormat, cache_dir: &Path)
     };
 
     cache_dir.join(to_save_file_name(page)).with_extension(ext)
-}
-
-fn to_save_file_name(page: &str) -> String {
-    let regex = Regex::new("[^-0-9A-Za-z_]").expect("'[^0-9A-Za-z_]' should be a valid regex");
-    regex.replace_all(page, "_").to_string()
 }
 
 /// Check if a page has been cached.
@@ -112,13 +141,18 @@ pub fn extract_tag_attr(element: &Element, tag: &HtmlTag, attr: &str) -> Option<
 
 /// Replaces relative URLs in certain HTML attributes with absolute URLs.
 /// The list of attributes is taken from https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
-fn update_relative_urls(html: &str) -> String {
+pub fn update_relative_urls(html: &str) -> String {
     html.replace("href=\"/", "href=\"https://wiki.archlinux.org/")
         .replace("src=\"/", "src=\"https://wiki.archlinux.org/")
         .replace("data=\"/", "data=\"https://wiki.archlinux.org/")
         .replace("manifest=\"/", "manifest=\"https://wiki.archlinux.org/")
         .replace("ping=\"/", "ping=\"https://wiki.archlinux.org/")
         .replace("poster=\"/", "poster=\"https://wiki.archlinux.org/")
+}
+
+fn to_save_file_name(page: &str) -> String {
+    let regex = Regex::new("[^-0-9A-Za-z_]").expect("'[^0-9A-Za-z_]' should be a valid regex");
+    regex.replace_all(page, "_").to_string()
 }
 
 #[cfg(test)]
@@ -142,45 +176,58 @@ mod tests {
     }
 
     #[test]
-    #[allow(unreachable_code)]
-    fn test_get_top_pages() {
-        return;
-        todo!("make fuzzy matcher better");
-        // short list
-        {
-            let out = get_top_pages("test", 2, &["tes", "tester", "Hippo"]);
-            dbg!(&out);
-            assert_eq!(out, ["tes", "tester"].to_vec());
+    fn test_process_open_search() {
+        let valid_input = vec![
+            OpenSearchItem::Single("test".to_owned()),
+            OpenSearchItem::Array(vec!["name 1".to_owned(), "name 2".to_owned()]),
+            OpenSearchItem::Array(vec![]),
+            OpenSearchItem::Array(vec!["url 1".to_owned(), "url 2".to_owned()]),
+        ];
+
+        let missing_elements = vec![OpenSearchItem::Single("test".to_owned())];
+        let not_arrays = vec![
+            OpenSearchItem::Single("test".to_owned()),
+            OpenSearchItem::Array(vec!["name 1".to_owned(), "name 2".to_owned()]),
+            OpenSearchItem::Array(vec![]),
+            OpenSearchItem::Single("invalid".to_owned()),
+        ];
+        let different_lengths = vec![
+            OpenSearchItem::Single("test".to_owned()),
+            OpenSearchItem::Array(vec!["name 1".to_owned()]),
+            OpenSearchItem::Array(vec![]),
+            OpenSearchItem::Array(vec!["url 1".to_owned(), "url 2".to_owned()]),
+        ];
+
+        assert_eq!(
+            open_search_to_page_url_tupel(valid_input).unwrap(),
+            vec![
+                ("name 1".to_owned(), "url 1".to_owned()),
+                ("name 2".to_owned(), "url 2".to_owned())
+            ]
+        );
+
+        match open_search_to_page_url_tupel(missing_elements).unwrap_err() {
+            WikiError::InvalidApiResponse(res) => {
+                assert_eq!(res, InvalidApiResponseError::OpenSearchMissingNthElement(1))
+            }
+            _ => panic!("expected error to be of type 'InvalidApiResponse'"),
         }
 
-        // long list
-        {
-            let search = "noexistent item";
+        match open_search_to_page_url_tupel(not_arrays).unwrap_err() {
+            WikiError::InvalidApiResponse(res) => {
+                assert_eq!(
+                    res,
+                    InvalidApiResponseError::OpenSearchNthElementShouldBeArray(3)
+                )
+            }
+            _ => panic!("expected error to be of type 'InvalidApiResponse'"),
+        }
 
-            let recommendations = [
-                "noexistent ie",
-                "noexist",
-                "existent it",
-                "item",
-                "existent i",
-                "gdjaskfjslsvcsf",
-                "jkjzcffsdfsf",
-                "fjffjfsdfds",
-            ];
-
-            let out = get_top_pages(search, 5, &recommendations);
-
-            assert_eq!(
-                out,
-                [
-                    "noexistent pa",
-                    "noexist",
-                    "existent page",
-                    "page",
-                    "existent p",
-                ]
-                .to_vec()
-            );
+        match open_search_to_page_url_tupel(different_lengths).unwrap_err() {
+            WikiError::InvalidApiResponse(res) => {
+                assert_eq!(res, InvalidApiResponseError::OpenSearchArraysLengthMismatch)
+            }
+            _ => panic!("expected error to be of type 'InvalidApiResponse'"),
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -79,13 +79,13 @@ pub fn extract_tag_attr(element: &Element, tag: &HtmlTag, attr: &str) -> Option<
 
 /// Replaces relative URLs in certain HTML attributes with absolute URLs.
 /// The list of attributes is taken from https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
-pub fn update_relative_urls(html: &str) -> String {
-    html.replace("href=\"/", "href=\"https://wiki.archlinux.org/")
-        .replace("src=\"/", "src=\"https://wiki.archlinux.org/")
-        .replace("data=\"/", "data=\"https://wiki.archlinux.org/")
-        .replace("manifest=\"/", "manifest=\"https://wiki.archlinux.org/")
-        .replace("ping=\"/", "ping=\"https://wiki.archlinux.org/")
-        .replace("poster=\"/", "poster=\"https://wiki.archlinux.org/")
+pub fn update_relative_urls(html: &str, base_url: &str) -> String {
+    html.replace("href=\"/", &format!("href=\"{base_url}/"))
+        .replace("src=\"/", &format!("src=\"{base_url}/"))
+        .replace("data=\"/", &format!("data=\"{base_url}/"))
+        .replace("manifest=\"/", &format!("manifest=\"{base_url}/"))
+        .replace("ping=\"/", &format!("ping=\"{base_url}/"))
+        .replace("poster=\"/", &format!("poster=\"{base_url}/"))
 }
 
 /// Convert an open search response into a list of name and URL pairs

--- a/src/wiki_api.rs
+++ b/src/wiki_api.rs
@@ -16,12 +16,9 @@ pub enum OpenSearchItem {
 
 pub async fn fetch_open_search(
     search: &str,
-    lang: Option<&str>,
-    limit: Option<u16>,
+    lang: &str,
+    limit: u16,
 ) -> Result<Vec<OpenSearchItem>, WikiError> {
-    let lang = lang.unwrap_or("en");
-    let limit = limit.unwrap_or(5);
-
     let url = format!("https://wiki.archlinux.org/api.php?action=opensearch&format=json&uselang={lang}&limit={limit}&search={search}");
     let body = reqwest::get(url).await?.text().await?;
     let res: Vec<OpenSearchItem> = serde_json::from_str(&body)?;

--- a/src/wiki_api.rs
+++ b/src/wiki_api.rs
@@ -1,4 +1,44 @@
+use scraper::Html;
+
+use crate::{error::WikiError, utils::update_relative_urls};
+
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct ApiResponse<T> {
     pub query: T,
+}
+
+#[derive(Debug, PartialEq, Eq, serde::Deserialize)]
+#[serde(untagged)]
+pub enum OpenSearchItem {
+    Single(String),
+    Array(Vec<String>),
+}
+
+pub async fn fetch_open_search(
+    search: &str,
+    lang: Option<&str>,
+    limit: Option<u16>,
+) -> Result<Vec<OpenSearchItem>, WikiError> {
+    let lang = lang.unwrap_or("en");
+    let limit = limit.unwrap_or(5);
+
+    let url = format!("https://wiki.archlinux.org/api.php?action=opensearch&format=json&uselang={lang}&limit={limit}&search={search}");
+    let body = reqwest::get(url).await?.text().await?;
+    let res: Vec<OpenSearchItem> = serde_json::from_str(&body)?;
+
+    // the first item in the response should be the search term
+    debug_assert_eq!(res.get(0), Some(&OpenSearchItem::Single(search.to_owned())));
+
+    return Ok(res);
+}
+
+/// Gets an ArchWiki pages entire content. Also updates all relative URLs to absolute URLs.
+/// `/title/Neovim` -> `https://wiki.archlinux.org/title/Neovim`
+pub async fn fetch_page(page: &str) -> Result<Html, reqwest::Error> {
+    let url = format!("https://wiki.archlinux.org/title/{page}");
+
+    let body = reqwest::get(&url).await?.text().await?;
+    let body_with_abs_urls = update_relative_urls(&body);
+
+    Ok(Html::parse_document(&body_with_abs_urls))
 }

--- a/src/wiki_api.rs
+++ b/src/wiki_api.rs
@@ -30,7 +30,7 @@ pub async fn fetch_open_search(
     // the first item in the response should be the search term
     debug_assert_eq!(res.get(0), Some(&OpenSearchItem::Single(search.to_owned())));
 
-    return Ok(res);
+    Ok(res)
 }
 
 /// Gets an ArchWiki pages entire content. Also updates all relative URLs to absolute URLs.

--- a/src/wiki_api.rs
+++ b/src/wiki_api.rs
@@ -1,6 +1,9 @@
 use scraper::Html;
 
-use crate::{error::WikiError, utils::update_relative_urls};
+use crate::{
+    error::WikiError,
+    utils::{open_search_get_exact_match_url, open_search_to_page_names, update_relative_urls},
+};
 
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct ApiResponse<T> {
@@ -31,8 +34,18 @@ pub async fn fetch_open_search(
 
 /// Gets an ArchWiki pages entire content. Also updates all relative URLs to absolute URLs.
 /// `/title/Neovim` -> `https://wiki.archlinux.org/title/Neovim`
-pub async fn fetch_page(page: &str) -> Result<Html, reqwest::Error> {
-    let url = format!("https://wiki.archlinux.org/title/{page}");
+///
+/// If the ArchWiki page doesn't have exists the top 5 pages that are most
+/// like the page that was given as an argument are returned as a `NoPageFound` error.
+pub async fn fetch_page(page: &str, lang: Option<&str>) -> Result<Html, WikiError> {
+    let lang = lang.unwrap_or("en");
+
+    let search_res = fetch_open_search(page, lang, 5).await?;
+
+    let Some(url) = open_search_get_exact_match_url(page, &search_res)? else {
+        let similar_pages = open_search_to_page_names(&search_res)?;
+        return Err(WikiError::NoPageFound(similar_pages.join("\n")));
+    };
 
     let body = reqwest::get(&url).await?.text().await?;
     let body_with_abs_urls = update_relative_urls(&body);


### PR DESCRIPTION
- allow fetching and parsing of open search results
- use recommendations from api search
- check if a page exists through search api
- Remove fuzzy-matcher from dependencies
- make relative urls depend on the base wiki url
- update readme to match new implementation
- clippy lints
- rename incorrect test name
