### PR TITLE
Add multi language support for read-page command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,7 @@ pub enum Commands {
         #[arg(short, long, value_enum, default_value_t = PageFormat::PlainText)]
         /// The format that the page should be displayed in
         format: PageFormat,
+        /// The name of the page to read or an absolute URL to the page
         page: String,
     },
     #[command(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,9 @@ pub enum Commands {
         #[arg(short, long)]
         /// Show URLs for plain-text output
         show_urls: bool,
+        #[arg(short, long)]
+        /// Preferred page language
+        lang: Option<String>,
         #[arg(short, long, value_enum, default_value_t = PageFormat::PlainText)]
         /// The format that the page should be displayed in
         format: PageFormat,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ use directories::BaseDirs;
 use error::WikiError;
 use formats::plain_text::convert_page_to_plain_text;
 use itertools::Itertools;
+use url::Url;
+use wiki_api::fetch_page_by_url;
 
 use crate::{
     formats::{html::convert_page_to_html, markdown::convert_page_to_markdown, PageFormat},
@@ -70,7 +72,10 @@ async fn main() -> Result<(), WikiError> {
             let out = if use_cached_page {
                 fs::read_to_string(&page_cache_path)?
             } else {
-                let document = fetch_page(&page, lang.as_ref().map(|x| x.as_str())).await?;
+                let document = match Url::parse(&page) {
+                    Ok(url) => fetch_page_by_url(url).await?,
+                    Err(_) => fetch_page(&page, lang.as_ref().map(|x| x.as_str())).await?,
+                };
 
                 match format {
                     PageFormat::PlainText => convert_page_to_plain_text(&document, show_urls),

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,7 @@ async fn main() -> Result<(), WikiError> {
             ignore_cache,
             disable_cache_invalidation,
             show_urls,
+            lang,
             format,
         } => {
             let page_cache_path = create_cache_page_path(&page, &format, &cache_dir);
@@ -69,7 +70,7 @@ async fn main() -> Result<(), WikiError> {
             let out = if use_cached_page {
                 fs::read_to_string(&page_cache_path)?
             } else {
-                let document = fetch_page(&page, None).await?;
+                let document = fetch_page(&page, lang.as_ref().map(|x| x.as_str())).await?;
 
                 match format {
                     PageFormat::PlainText => convert_page_to_plain_text(&document, show_urls),


### PR DESCRIPTION
- Add lang argument to 'read-page' command
- allow absolute URLs to be passed in as valid page args to 'read-page' command
