### PR TITLE
Make sync and list commands more dynamic with io

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand};
 
 use crate::formats::PageFormat;
@@ -63,12 +65,19 @@ pub enum Commands {
         #[arg(short, long)]
         /// Flatten all pages and don't show their category names
         flatten: bool,
+        #[arg(short, long)]
+        /// Use different file to read pages from
+        page_file: Option<PathBuf>,
     },
     #[command(
         about = "List all categories from the ArchWiki that have been downloaded",
         long_about = "List categories  from the ArchWiki that have been downloaded. See 'update-all' or 'update-category' for information on downloading."
     )]
-    ListCategories,
+    ListCategories {
+        #[arg(short, long)]
+        /// Use different file to read pages from
+        page_file: Option<PathBuf>,
+    },
     #[command(
         about = "List all languages that the ArchWiki supports",
         long_about = "List all languages that the ArchWiki supports."

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,11 +49,7 @@ async fn main() -> Result<(), WikiError> {
     fs::create_dir_all(&cache_dir)?;
     fs::create_dir_all(&data_dir)?;
 
-    let pages_path = data_dir.join(PAGE_FILE_NAME);
-    let pages_map: HashMap<String, Vec<String>> = match fs::read_to_string(&pages_path) {
-        Ok(file) => serde_yaml::from_str(&file)?,
-        Err(_) => HashMap::default(),
-    };
+    let default_page_file_path = data_dir.join(PAGE_FILE_NAME);
 
     match args.command {
         Commands::ReadPage {
@@ -116,11 +112,17 @@ async fn main() -> Result<(), WikiError> {
 
             println!("{out}");
         }
-        Commands::ListPages { flatten } => {
+        Commands::ListPages { flatten, page_file } => {
+            let file = fs::read_to_string(page_file.unwrap_or(default_page_file_path))?;
+            let pages_map: HashMap<String, Vec<String>> = serde_yaml::from_str(&file)?;
+
             let out = list_pages(&pages_map, flatten);
             println!("{out}");
         }
-        Commands::ListCategories => {
+        Commands::ListCategories { page_file } => {
+            let file = fs::read_to_string(page_file.unwrap_or(default_page_file_path))?;
+            let pages_map: HashMap<String, Vec<String>> = serde_yaml::from_str(&file)?;
+
             let out = pages_map.keys().unique().sorted().join("\n");
             println!("{out}");
         }
@@ -146,14 +148,13 @@ async fn main() -> Result<(), WikiError> {
             )
             .await?;
 
-            let sorted_res = res.into_iter().sorted().collect_vec();
-            let out = serde_yaml::to_string(&sorted_res)?;
+            let out = serde_yaml::to_string(&res)?;
 
             if !print {
-                fs::write(&pages_path, out)?;
+                fs::write(&default_page_file_path, out)?;
 
                 if !hide_progress {
-                    println!("data saved to {}", pages_path.to_string_lossy());
+                    println!("data saved to {}", default_page_file_path.to_string_lossy());
                 }
             } else {
                 println!("{out}");


### PR DESCRIPTION
- add args to 'sync-wiki' command to make it more usable for other applications
- allow 'list-pages' and 'list-categories' commands to take files as input
